### PR TITLE
Feat/forgot and reset password

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
 import Home from "../pages/Home/Home";
 import Login from "../pages/Login/Login";
+import ForgotPassword from "../pages/ForgotPassword/ForgotPassword";
+import ResetPassword from "../pages/ResetPassword/ResetPassword";
 
 const App: React.FC = () => {
   return (
@@ -9,6 +11,8 @@ const App: React.FC = () => {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/login" element={<Login />} />
+        <Route path="/forgot-password" element={<ForgotPassword />} />
+        <Route path="/reset-password" element={<ResetPassword />} />
       </Routes>
     </Router>
   );

--- a/src/features/auth/passwordApi.ts
+++ b/src/features/auth/passwordApi.ts
@@ -1,0 +1,31 @@
+import { apiSlice } from "../../api/apiSlice";
+
+interface IForgotPasswordRequest {
+  email: string;
+}
+
+interface IResetPasswordRequest {
+  token: string;
+  password: string;
+}
+
+export const passwordApi = apiSlice.injectEndpoints({
+  endpoints: (builder) => ({
+    forgotPassword: builder.mutation<{ message: string }, IForgotPasswordRequest>({
+      query: (body) => ({
+        url: "/auth/forgot-password",
+        method: "POST",
+        body,
+      }),
+    }),
+    resetPassword: builder.mutation<{ message: string }, IResetPasswordRequest>({
+      query: (body) => ({
+        url: "/auth/reset-password",
+        method: "POST",
+        body,
+      }),
+    }),
+  }),
+});
+
+export const { useForgotPasswordMutation, useResetPasswordMutation } = passwordApi;

--- a/src/features/auth/passwordApi.ts
+++ b/src/features/auth/passwordApi.ts
@@ -4,21 +4,30 @@ interface IForgotPasswordRequest {
   email: string;
 }
 
+interface IForgotPasswordResponse {
+  message: string;
+  token: string;
+}
+
 interface IResetPasswordRequest {
   token: string;
   password: string;
 }
 
+interface IResetPasswordResponse {
+  message: string;
+}
+
 export const passwordApi = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
-    forgotPassword: builder.mutation<{ message: string }, IForgotPasswordRequest>({
+    forgotPassword: builder.mutation<IForgotPasswordResponse, IForgotPasswordRequest>({
       query: (body) => ({
         url: "/auth/forgot-password",
         method: "POST",
         body,
       }),
     }),
-    resetPassword: builder.mutation<{ message: string }, IResetPasswordRequest>({
+    resetPassword: builder.mutation<IResetPasswordResponse, IResetPasswordRequest>({
       query: (body) => ({
         url: "/auth/reset-password",
         method: "POST",

--- a/src/pages/ForgotPassword/ForgotPassword.module.scss
+++ b/src/pages/ForgotPassword/ForgotPassword.module.scss
@@ -1,0 +1,40 @@
+.layout {
+  min-height: 100vh;
+}
+
+.header {
+  background-color: #001529;
+  color: white;
+  text-align: center;
+  font-size: 1.5rem;
+}
+
+.content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.form {
+  width: 100%;
+  max-width: 400px;
+  padding: 2rem;
+  background-color: #fff;
+  border: 1px solid #dcdcdc;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.input {
+  width: 100%;
+}
+
+.submitButton {
+  width: 100%;
+}
+
+.backLink {
+  display: block;
+  text-align: center;
+  margin-top: 1rem;
+}

--- a/src/pages/ForgotPassword/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword/ForgotPassword.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Form, Input, Button, Layout, message } from "antd";
 import type { FormProps } from "antd";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { useForgotPasswordMutation } from "../../features/auth/passwordApi";
 import styles from "./ForgotPassword.module.scss";
 
@@ -12,16 +12,18 @@ interface IForgotPasswordFormValues {
 }
 
 const ForgotPassword: React.FC = () => {
+  const navigate = useNavigate();
   const [forgotPassword, { isLoading }] = useForgotPasswordMutation();
 
   const onFinish: FormProps<IForgotPasswordFormValues>["onFinish"] = async (
     values,
   ) => {
     try {
-      await forgotPassword({ email: values.email }).unwrap();
-      message.success(
-        "If that email exists, a reset link has been sent.",
-      );
+      const data = await forgotPassword({
+        email: values.email,
+      }).unwrap();
+      message.success(data.message);
+      navigate(`/reset-password?token=${data.token}`);
     } catch (error) {
       const errorMessage =
         error instanceof Error ? error.message : "Request failed";

--- a/src/pages/ForgotPassword/ForgotPassword.tsx
+++ b/src/pages/ForgotPassword/ForgotPassword.tsx
@@ -1,0 +1,71 @@
+import React from "react";
+import { Form, Input, Button, Layout, message } from "antd";
+import type { FormProps } from "antd";
+import { Link } from "react-router-dom";
+import { useForgotPasswordMutation } from "../../features/auth/passwordApi";
+import styles from "./ForgotPassword.module.scss";
+
+const { Header, Content } = Layout;
+
+interface IForgotPasswordFormValues {
+  email: string;
+}
+
+const ForgotPassword: React.FC = () => {
+  const [forgotPassword, { isLoading }] = useForgotPasswordMutation();
+
+  const onFinish: FormProps<IForgotPasswordFormValues>["onFinish"] = async (
+    values,
+  ) => {
+    try {
+      await forgotPassword({ email: values.email }).unwrap();
+      message.success(
+        "If that email exists, a reset link has been sent.",
+      );
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Request failed";
+      message.error(errorMessage);
+    }
+  };
+
+  return (
+    <Layout className={styles.layout}>
+      <Header className={styles.header}>Forgot Password</Header>
+      <Content className={styles.content}>
+        <Form
+          name="forgotPassword"
+          className={styles.form}
+          onFinish={onFinish}
+        >
+          <Form.Item
+            name="email"
+            rules={[
+              { required: true, message: "Please input your email!" },
+              { type: "email", message: "Please enter a valid email!" },
+            ]}
+          >
+            <Input placeholder="Email" className={styles.input} />
+          </Form.Item>
+
+          <Form.Item>
+            <Button
+              type="primary"
+              htmlType="submit"
+              className={styles.submitButton}
+              loading={isLoading}
+            >
+              Send Reset Link
+            </Button>
+          </Form.Item>
+
+          <Link to="/login" className={styles.backLink}>
+            Back to Login
+          </Link>
+        </Form>
+      </Content>
+    </Layout>
+  );
+};
+
+export default ForgotPassword;

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { Form, Input, Button, Layout, message } from "antd";
 import type { FormProps } from "antd";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, Link } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "../../store/hooks";
 import { setUsername } from "../../features/auth/authSlice";
 import { useLoginMutation } from "../../features/auth/authApi";
@@ -69,6 +69,10 @@ const Login: React.FC = () => {
             rules={[{ required: true, message: "Please input your password!" }]}
           >
             <Input.Password placeholder="Password" className={styles.input} />
+          </Form.Item>
+
+          <Form.Item>
+            <Link to="/forgot-password">Forgot password?</Link>
           </Form.Item>
 
           <Form.Item>

--- a/src/pages/ResetPassword/ResetPassword.module.scss
+++ b/src/pages/ResetPassword/ResetPassword.module.scss
@@ -1,0 +1,40 @@
+.layout {
+  min-height: 100vh;
+}
+
+.header {
+  background-color: #001529;
+  color: white;
+  text-align: center;
+  font-size: 1.5rem;
+}
+
+.content {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.form {
+  width: 100%;
+  max-width: 400px;
+  padding: 2rem;
+  background-color: #fff;
+  border: 1px solid #dcdcdc;
+  border-radius: 8px;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.input {
+  width: 100%;
+}
+
+.submitButton {
+  width: 100%;
+}
+
+.backLink {
+  display: block;
+  text-align: center;
+  margin-top: 1rem;
+}

--- a/src/pages/ResetPassword/ResetPassword.tsx
+++ b/src/pages/ResetPassword/ResetPassword.tsx
@@ -1,0 +1,110 @@
+import React from "react";
+import { Form, Input, Button, Layout, message } from "antd";
+import type { FormProps } from "antd";
+import { useNavigate, useSearchParams, Link } from "react-router-dom";
+import { useResetPasswordMutation } from "../../features/auth/passwordApi";
+import styles from "./ResetPassword.module.scss";
+
+const { Header, Content } = Layout;
+
+interface IResetPasswordFormValues {
+  password: string;
+  confirmPassword: string;
+}
+
+const ResetPassword: React.FC = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get("token");
+  const [resetPassword, { isLoading }] = useResetPasswordMutation();
+
+  const onFinish: FormProps<IResetPasswordFormValues>["onFinish"] = async (
+    values,
+  ) => {
+    if (!token) return;
+    try {
+      await resetPassword({ token, password: values.password }).unwrap();
+      message.success("Password reset successfully. Please log in.");
+      navigate("/login");
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : "Password reset failed";
+      message.error(errorMessage);
+    }
+  };
+
+  if (!token) {
+    return (
+      <Layout className={styles.layout}>
+        <Header className={styles.header}>Reset Password</Header>
+        <Content className={styles.content}>
+          <div className={styles.form}>
+            <p>Invalid or missing reset token.</p>
+            <Link to="/login" className={styles.backLink}>
+              Back to Login
+            </Link>
+          </div>
+        </Content>
+      </Layout>
+    );
+  }
+
+  return (
+    <Layout className={styles.layout}>
+      <Header className={styles.header}>Reset Password</Header>
+      <Content className={styles.content}>
+        <Form
+          name="resetPassword"
+          className={styles.form}
+          onFinish={onFinish}
+        >
+          <Form.Item
+            name="password"
+            rules={[
+              { required: true, message: "Please input your new password!" },
+              { min: 8, message: "Password must be at least 8 characters!" },
+            ]}
+          >
+            <Input.Password placeholder="New Password" className={styles.input} />
+          </Form.Item>
+
+          <Form.Item
+            name="confirmPassword"
+            dependencies={["password"]}
+            rules={[
+              { required: true, message: "Please confirm your new password!" },
+              ({ getFieldValue }) => ({
+                validator(_, value) {
+                  if (!value || getFieldValue("password") === value) {
+                    return Promise.resolve();
+                  }
+                  return Promise.reject(
+                    new Error("Passwords do not match!"),
+                  );
+                },
+              }),
+            ]}
+          >
+            <Input.Password
+              placeholder="Confirm New Password"
+              className={styles.input}
+            />
+          </Form.Item>
+
+          <Form.Item>
+            <Button
+              type="primary"
+              htmlType="submit"
+              className={styles.submitButton}
+              loading={isLoading}
+            >
+              Reset Password
+            </Button>
+          </Form.Item>
+        </Form>
+      </Content>
+    </Layout>
+  );
+};
+
+export default ResetPassword;


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description
---

This pull request introduces a complete "Forgot Password" and "Reset Password" flow to the application, including new API endpoints, pages, and navigation updates. Users can now request a password reset link from the login page, receive a token, and set a new password using the reset page.

## 📸 Screenshots (if applicable)
---

Forgot Password Page:

<img width="1340" height="726" alt="Screenshot 2026-05-10 at 20 14 54" src="https://github.com/user-attachments/assets/0ecd389c-48e9-4a97-841a-79ecd30e1896" />

---

Testing endpoint on backend:

<img width="637" height="97" alt="Screenshot 2026-05-10 at 20 15 50" src="https://github.com/user-attachments/assets/cc08f010-23ab-491f-804c-4213ff2078b5" />

---

Re-direct Page with mock token to Reset Password Page

<img width="669" height="363" alt="Screenshot 2026-05-10 at 20 16 08" src="https://github.com/user-attachments/assets/f775f654-d1ae-411a-a334-23591aedb8af" />

---

Testing endpoint on backend:

<img width="626" height="81" alt="Screenshot 2026-05-10 at 20 16 36" src="https://github.com/user-attachments/assets/5ac181d5-e5cf-403f-b617-647daa540e7e" />

## 🧠 Additional Context

Add any other context or screenshots about the pull request here.
